### PR TITLE
updated for Bluespec 2014.07.A or later

### DIFF
--- a/xilinx/aurora_64b66b/AuroraExtImport.bsv
+++ b/xilinx/aurora_64b66b/AuroraExtImport.bsv
@@ -215,7 +215,11 @@ module mkAuroraExt#(Clock gtx_clk_p, Clock gtx_clk_n, Clock clk50) (AuroraExtIfc
 	MakeResetIfc rst50ifc2 <- mkReset(8, True, clk50);
 	Reset rst50_2 = rst50ifc2.new_rst;
 	//Reset rst50_2 <- mkAsyncReset(2, defaultReset, clk50);
-	Clock auroraExt_gtx_clk <- mkClockIBUFDS_GTE2(True, gtx_clk_p, gtx_clk_n);
+	Clock auroraExt_gtx_clk <- mkClockIBUFDS_GTE2(
+`ifdef ClockDefaultParam
+						      defaultValue,
+`endif
+						      True, gtx_clk_p, gtx_clk_n);
 
 	AuroraExtImportIfc#(AuroraExtPerQuad) auroraExtImport <- mkAuroraExtImport(auroraExt_gtx_clk, clk50, rst50, rst50_2);
 `else

--- a/xilinx/aurora_64b66b/AuroraExtImport117.bsv
+++ b/xilinx/aurora_64b66b/AuroraExtImport117.bsv
@@ -31,7 +31,11 @@ module mkAuroraExt117#(Clock gtx_clk_p, Clock gtx_clk_n, Clock clk50) (AuroraExt
 	MakeResetIfc rst50ifc2 <- mkReset(8, True, clk50);
 	Reset rst50_2 = rst50ifc2.new_rst;
 	//Reset rst50_2 <- mkAsyncReset(2, defaultReset, clk50);
-	Clock auroraExt_gtx_clk <- mkClockIBUFDS_GTE2(True, gtx_clk_p, gtx_clk_n);
+	Clock auroraExt_gtx_clk <- mkClockIBUFDS_GTE2(
+`ifdef ClockDefaultParam
+						      defaultValue,
+`endif
+						      True, gtx_clk_p, gtx_clk_n);
 
 	AuroraExtImportIfc#(AuroraExtPerQuad) auroraExtImport <- mkAuroraExtImport117(auroraExt_gtx_clk, clk50, rst50, rst50_2);
 `else

--- a/xilinx/aurora_8b10b_fmc1/AuroraImportFmc1.bsv
+++ b/xilinx/aurora_8b10b_fmc1/AuroraImportFmc1.bsv
@@ -48,7 +48,11 @@ module mkAuroraIntra#(Clock gtx_clk_p, Clock gtx_clk_n, Clock clk250) (AuroraIfc
 	Reset rst50 <- mkAsyncReset(2, defaultReset, clk50);
 	Reset rst50_2 = rst50ifc2.new_rst;
 	Reset rst50_2a <- mkAsyncReset(2, rst50_2, clk50);
-	Clock fmc1_gtx_clk_i <- mkClockIBUFDS_GTE2(True, gtx_clk_p, gtx_clk_n);
+	Clock fmc1_gtx_clk_i <- mkClockIBUFDS_GTE2(
+`ifdef ClockDefaultParam
+						   defaultValue,
+`endif
+						   True, gtx_clk_p, gtx_clk_n);
 	AuroraImportIfc#(4) auroraIntraImport <- mkAuroraImport_8b10b_fmc1(fmc1_gtx_clk_i, clk50, rst50, /*rst50*/rst50_2a);
 `else
 	//Clock gtx_clk = cur_clk;


### PR DESCRIPTION
Bluespec 2014.07.A added a parameter to mkClockIBUFDS_GTE2. Connectal detects the version of Bluespec and defines ClockDefaultParam if the extra parameter is needed. This commit updates Bluedbm to build with recent Bluespec releases.